### PR TITLE
Moved `catsinstances` to `cats.instances`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import org.scalajs.linker.interface.ESVersion
+import com.typesafe.tools.mima.core._
 
 val projectName = "parsley-cats"
 val Scala213 = "2.13.10"
@@ -19,9 +20,18 @@ inThisBuild(List(
   versionScheme := Some("early-semver"),
   crossScalaVersions := Seq(Scala213, Scala212, Scala3),
   scalaVersion := Scala213,
+  mimaBinaryIssueFilters ++= Seq(
+    // Until 2.0 (these are all misreported package private members)
+    ProblemFilters.exclude[MissingClassProblem]("parsley.ApplicativeForParsley"),
+    ProblemFilters.exclude[MissingClassProblem]("parsley.DeferForParsley"),
+    ProblemFilters.exclude[MissingClassProblem]("parsley.FunctorFilterForParsley"),
+    ProblemFilters.exclude[MissingClassProblem]("parsley.FunctorForParsley"),
+    ProblemFilters.exclude[MissingClassProblem]("parsley.MonadForParsley"),
+    ProblemFilters.exclude[MissingClassProblem]("parsley.MonoidKForParsley"),
+  ),
   // CI Configuration
   tlCiReleaseBranches := Seq("master"),
-  tlSonatypeUseLegacyHost := false, // this needs to be switched off when we migrate parsley to the other server too
+  tlSonatypeUseLegacyHost := false,
   githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8"), JavaSpec.temurin("11"), JavaSpec.temurin("17")),
 ))
 

--- a/parsley-cats/shared/src/main/scala-2.12/parsley/cats/MonoidKForParsley.scala
+++ b/parsley-cats/shared/src/main/scala-2.12/parsley/cats/MonoidKForParsley.scala
@@ -1,7 +1,10 @@
 /* SPDX-FileCopyrightText: © 2022 Parsley Cats Contributors <https://github.com/j-mie6/parsley-cats/graphs/contributors>
  * SPDX-License-Identifier: BSD-3-Clause
  */
-package parsley
+package parsley.cats
+
+import parsley.Parsley
+import parsley.combinator
 
 import cats.{Functor, MonoidK}
 
@@ -12,6 +15,6 @@ private [parsley] trait MonoidKForParsley extends MonoidK[Parsley] {
 
     // MonoidK Overrides
     override def sum[A, B](mx: Parsley[A], my: Parsley[B])(implicit F: Functor[Parsley]): Parsley[Either[A,B]] = mx <+> my
-    override def combineAllK[A](ps: IterableOnce[Parsley[A]]): Parsley[A] = combinator.choice(ps.iterator.toSeq: _*)
-    override def combineAllOptionK[A](ps: IterableOnce[Parsley[A]]): Option[Parsley[A]] = ps.iterator.reduceRightOption(_<|>_)
+    override def combineAllK[A](ps: TraversableOnce[Parsley[A]]): Parsley[A] = combinator.choice(ps.toIterator.toSeq: _*)
+    override def combineAllOptionK[A](ps: TraversableOnce[Parsley[A]]): Option[Parsley[A]] = ps.toIterator.reduceRightOption(_<|>_)
 }

--- a/parsley-cats/shared/src/main/scala-2.13+/parsley/cats/MonoidKForParsley.scala
+++ b/parsley-cats/shared/src/main/scala-2.13+/parsley/cats/MonoidKForParsley.scala
@@ -1,7 +1,10 @@
 /* SPDX-FileCopyrightText: © 2022 Parsley Cats Contributors <https://github.com/j-mie6/parsley-cats/graphs/contributors>
  * SPDX-License-Identifier: BSD-3-Clause
  */
-package parsley
+package parsley.cats
+
+import parsley.Parsley
+import parsley.combinator
 
 import cats.{Functor, MonoidK}
 
@@ -12,6 +15,6 @@ private [parsley] trait MonoidKForParsley extends MonoidK[Parsley] {
 
     // MonoidK Overrides
     override def sum[A, B](mx: Parsley[A], my: Parsley[B])(implicit F: Functor[Parsley]): Parsley[Either[A,B]] = mx <+> my
-    override def combineAllK[A](ps: TraversableOnce[Parsley[A]]): Parsley[A] = combinator.choice(ps.toIterator.toSeq: _*)
-    override def combineAllOptionK[A](ps: TraversableOnce[Parsley[A]]): Option[Parsley[A]] = ps.toIterator.reduceRightOption(_<|>_)
+    override def combineAllK[A](ps: IterableOnce[Parsley[A]]): Parsley[A] = combinator.choice(ps.iterator.toSeq: _*)
+    override def combineAllOptionK[A](ps: IterableOnce[Parsley[A]]): Option[Parsley[A]] = ps.iterator.reduceRightOption(_<|>_)
 }

--- a/parsley-cats/shared/src/main/scala/parsley/cats/ApplicativeForParsley.scala
+++ b/parsley-cats/shared/src/main/scala/parsley/cats/ApplicativeForParsley.scala
@@ -1,11 +1,13 @@
 /* SPDX-FileCopyrightText: © 2022 Parsley Cats Contributors <https://github.com/j-mie6/parsley-cats/graphs/contributors>
  * SPDX-License-Identifier: BSD-3-Clause
  */
-package parsley
+package parsley.cats
+
+import parsley.Parsley
+import parsley.combinator
+import parsley.lift._
 
 import cats.Applicative
-
-import lift._
 
 private [parsley] trait ApplicativeForParsley extends Applicative[Parsley] {
     override def pure[A](x: A): Parsley[A] = Parsley.pure(x)

--- a/parsley-cats/shared/src/main/scala/parsley/cats/DeferForParsley.scala
+++ b/parsley-cats/shared/src/main/scala/parsley/cats/DeferForParsley.scala
@@ -1,11 +1,11 @@
 /* SPDX-FileCopyrightText: © 2022 Parsley Cats Contributors <https://github.com/j-mie6/parsley-cats/graphs/contributors>
  * SPDX-License-Identifier: BSD-3-Clause
  */
-package parsley
+package parsley.cats
+
+import parsley.Parsley, Parsley.LazyParsley
 
 import cats.Defer
-
-import Parsley.LazyParsley
 
 private [parsley] class DeferForParsley extends Defer[Parsley] {
     def defer[A](p: =>parsley.Parsley[A]): parsley.Parsley[A] = ~p

--- a/parsley-cats/shared/src/main/scala/parsley/cats/FunctorFilterForParsley.scala
+++ b/parsley-cats/shared/src/main/scala/parsley/cats/FunctorFilterForParsley.scala
@@ -1,7 +1,9 @@
 /* SPDX-FileCopyrightText: © 2022 Parsley Cats Contributors <https://github.com/j-mie6/parsley-cats/graphs/contributors>
  * SPDX-License-Identifier: BSD-3-Clause
  */
-package parsley
+package parsley.cats
+
+import parsley.Parsley
 
 import cats.{Functor, FunctorFilter}
 

--- a/parsley-cats/shared/src/main/scala/parsley/cats/FunctorForParsley.scala
+++ b/parsley-cats/shared/src/main/scala/parsley/cats/FunctorForParsley.scala
@@ -1,7 +1,9 @@
 /* SPDX-FileCopyrightText: © 2022 Parsley Cats Contributors <https://github.com/j-mie6/parsley-cats/graphs/contributors>
  * SPDX-License-Identifier: BSD-3-Clause
  */
-package parsley
+package parsley.cats
+
+import parsley.Parsley
 
 import cats.Functor
 

--- a/parsley-cats/shared/src/main/scala/parsley/cats/MonadForParsley.scala
+++ b/parsley-cats/shared/src/main/scala/parsley/cats/MonadForParsley.scala
@@ -1,10 +1,13 @@
 /* SPDX-FileCopyrightText: © 2022 Parsley Cats Contributors <https://github.com/j-mie6/parsley-cats/graphs/contributors>
  * SPDX-License-Identifier: BSD-3-Clause
  */
-package parsley
+package parsley.cats
+
+import parsley.Parsley
+import parsley.combinator
+import parsley.registers.{RegisterMaker, RegisterMethods}
 
 import cats.{Alternative, Monad}
-import registers.{RegisterMaker, RegisterMethods}
 
 private [parsley] trait MonadForParsley extends Monad[Parsley] {
     override def flatMap[A, B](mx: Parsley[A])(f: A => Parsley[B]): Parsley[B] = mx.flatMap(f)

--- a/parsley-cats/shared/src/main/scala/parsley/cats/instances.scala
+++ b/parsley-cats/shared/src/main/scala/parsley/cats/instances.scala
@@ -1,18 +1,17 @@
-/* SPDX-FileCopyrightText: © 2022 Parsley Cats Contributors <https://github.com/j-mie6/parsley-cats/graphs/contributors>
- * SPDX-License-Identifier: BSD-3-Clause
- */
-package parsley
+package parsley.cats
+
+import parsley.Parsley
 
 import cats.{Defer, FunctorFilter, Monad, MonoidK}
 
 /** Contains instances for `cats` typeclasses.
   *
-  * @since 0.1.0
+  * @since 1.2.0
   */
-object catsinstances {
+object instances {
     /** Instance for the core `cats` typeclasses used with parser combinators.
       *
-      * @since 0.1.0
+      * @since 1.2.0
       */
     implicit val monadPlusForParsley: Monad[Parsley] with MonoidK[Parsley] with FunctorFilter[Parsley] =
         // This must be kept in this ordering, with more generic further up
@@ -23,7 +22,7 @@ object catsinstances {
 
     /** Instance for `cats` `Defer` typeclass, which allows for recursive parser generation.
       *
-      * @since 0.2.0
+      * @since 1.2.0
       */
     implicit val deferForParsley: Defer[Parsley] = new DeferForParsley
 }

--- a/parsley-cats/shared/src/main/scala/parsley/catsinstances.scala
+++ b/parsley-cats/shared/src/main/scala/parsley/catsinstances.scala
@@ -1,0 +1,27 @@
+/* SPDX-FileCopyrightText: © 2022 Parsley Cats Contributors <https://github.com/j-mie6/parsley-cats/graphs/contributors>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package parsley
+
+import _root_.cats.{Defer, FunctorFilter, Monad, MonoidK}
+
+/** Contains instances for `cats` typeclasses.
+  *
+  * @since 0.1.0
+  */
+@deprecated("This object has been renamed to `parsley.cats.instances`, this will be removed in parsley-cats 2", "1.2.0")
+object catsinstances {
+    /** Instance for the core `cats` typeclasses used with parser combinators.
+      *
+      * @since 0.1.0
+      */
+    @deprecated("This has been renamed to `parsley.cats.instances.monadPlusForParsley`, this will be removed in parsley-cats 2", "1.2.0")
+    implicit val monadPlusForParsley: Monad[Parsley] with MonoidK[Parsley] with FunctorFilter[Parsley] = parsley.cats.instances.monadPlusForParsley
+
+    /** Instance for `cats` `Defer` typeclass, which allows for recursive parser generation.
+      *
+      * @since 0.2.0
+      */
+    @deprecated("This has been renamed to `parsley.cats.instances.deferForParsley`, this will be removed in parsley-cats 2", "1.2.0")
+    implicit val deferForParsley: Defer[Parsley] = parsley.cats.instances.deferForParsley
+}

--- a/parsley-cats/shared/src/test/scala/parsley/cats/CatsSuite.scala
+++ b/parsley-cats/shared/src/test/scala/parsley/cats/CatsSuite.scala
@@ -1,12 +1,13 @@
-package parsley
+package parsley.cats
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 import org.scalactic.source.Position
 
-import parsley.Parsley.pure
+import parsley.Parsley, Parsley.pure
+import parsley.Success
 import parsley.character.{item, digit, char}
-import parsley.catsinstances._
+import parsley.cats.instances._
 
 import cats.laws.{MonadLaws, MonoidKLaws, FunctorFilterLaws}
 import cats.kernel.laws.IsEq


### PR DESCRIPTION
This will help make a uniform API as more sub-objects are added that exist already in `parsley` itself. Deprecation to be enforced in 2.0.0, but may be binary hidden in 1.3?